### PR TITLE
fix: embed title

### DIFF
--- a/src/yukari-san-notify/index.ts
+++ b/src/yukari-san-notify/index.ts
@@ -32,7 +32,7 @@ client.on('voiceStateUpdate', async (oldState, newState) => {
     const embed = new EmbedBuilder()
       .setColor(0xffd3fb)
       .setTitle(
-        `**${newState.guild.name}** の **${newState.channel?.name}** に **${newState.member.displayName}**さんが入室しました`
+        `${newState.guild.name} の ${newState.channel?.name} に ${newState.member.displayName}さんが入室しました`
       )
       .setImage(newState.member.user.displayAvatarURL())
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of voice channel join notifications so that the embed title now displays in plain text rather than using bold formatting. This change enhances the readability and ensures a consistent look when presenting member names, guild names, and channel names. It is part of our ongoing efforts to improve the overall clarity and user experience of system notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->